### PR TITLE
Replace 'ceph pg dump' with 'ceph -s' in cluster health check

### DIFF
--- a/tasks/restart_single_osd.yml
+++ b/tasks/restart_single_osd.yml
@@ -64,9 +64,10 @@
 
 
 - name: wait for PGs to become active+clean
-  command: ceph pg dump --format=json
-  register: pg_dump_post
+  command: ceph -s --format=json
+  register: ceph_health_post
   delegate_to: "{{ groups.mons[0] }}"
-  until: (pg_dump_post.stdout|from_json)['pg_stats']|groupby('state')|join('', attribute='grouper') == 'active+clean'
+  until: (ceph_health_post.stdout|from_json).pgmap.pgs_by_state|length == 1 and
+         (ceph_health_post.stdout|from_json).pgmap.pgs_by_state.0.state_name == "active+clean"
   retries: "{{ osd_restart_attempts }}"
   delay: "{{ osd_restart_delay }}"


### PR DESCRIPTION
Replace 'ceph pg dump --format json' with 'ceph -s --format json' in cluster health check to improve performance on
systems with many pg (10k+)