### PR TITLE
Support systemd for service restarting

### DIFF
--- a/tasks/restart_mons.yml
+++ b/tasks/restart_mons.yml
@@ -23,11 +23,18 @@
     /etc/init/ceph-mon.conf
   register: ceph_mon_group
 
-- name: stop ceph monitor
+- name: stop ceph monitor (upstart)
   service: >
     name=ceph-mon
     state=stopped
     args=id={{ inventory_hostname_short }}
+  when: ansible_service_mgr == "upstart"
+
+- name: stop ceph monitor (systemd)
+  service: >
+    name=ceph-mon@{{ inventory_hostname_short }}
+    state=stopped
+  when: ansible_service_mgr == "systemd"
 
 - name: fix mon data ownership
   file: >
@@ -41,11 +48,18 @@
     - ceph_mon_user.stdout != ''
     - mon_dir_stat.stat.pw_name != ceph_mon_user.stdout
 
-- name: start ceph monitor
+- name: start ceph monitor (upstart)
   service: >
     name=ceph-mon
     state=started
     args=id={{ inventory_hostname_short }}
+  when: ansible_service_mgr == "upstart"
+
+- name: start ceph monitor (systemd)
+  service:
+    name=ceph-mon@{{ inventory_hostname_short }}
+    state=started
+  when: ansible_service_mgr == "systemd"
 
 - name: wait for monitor to start up
   wait_for: >

--- a/tasks/restart_single_osd.yml
+++ b/tasks/restart_single_osd.yml
@@ -48,12 +48,22 @@
     - "{{ item not in (osdmap_flags.stdout|from_json) }}"
   delegate_to: "{{ groups.mons[0] }}"
 
-- name: stop OSD {{ osd_id }}
+- name: stop OSD {{ osd_id }} (upstart)
   service: >
     name=ceph-osd
     state=stopped
     args=id={{ osd_id }}
-  when: "{{ not(dont_restart_osd|default(False)|bool) }}"
+  when:
+    - "{{ not(dont_restart_osd|default(False)|bool) }}"
+    - ansible_service_mgr == "upstart"
+
+- name: stop OSD {{ osd_id }} (systemd)
+  service: >
+    name=ceph-osd@{{ osd_id }}
+    state=stopped
+  when:
+    - "{{ not(dont_restart_osd|default(False)|bool) }}"
+    - ansible_service_mgr == "systemd"
 
 - name: fix OSD data ownership
   file: >
@@ -68,12 +78,22 @@
     - osd_dir_stat.stat.pw_name != ceph_user.stdout
     - "{{ not(dont_restart_osd|default(False)|bool) }}"
 
-- name: start OSD {{ osd_id }}
+- name: start OSD {{ osd_id }} (upstart)
   service: >
     name=ceph-osd
     state=started
     args=id={{ osd_id }}
-  when: "{{ not(dont_restart_osd|default(False)|bool) }}"
+  when:
+    -"{{ not(dont_restart_osd|default(False)|bool) }}"
+    - ansible_service_mgr == "upstart"
+
+- name: start OSD {{ osd_id }} (systemd)
+  service: >
+    name=ceph-osd@{{ osd_id }}
+    state=started
+  when:
+    - "{{ not(dont_restart_osd|default(False)|bool) }}"
+    - ansible_service_mgr == "systemd"
 
 # Wait until all PGs are in the `active+clean' state.
 


### PR DESCRIPTION
The most crucial thing in this commit is using `ansible_hostname` instead of `inventory_hostname`. By default, Ceph systemd units are using hostnames, not `inventory_hostname` (it could be IP address).